### PR TITLE
Dev : Add ServiceDiscovery to GatewayWorker and fix GatewayWorker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "guzzlehttp/guzzle": "^7.0",
         "monolog/monolog": "^3.4",
         "vlucas/phpdotenv": "^5.5",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "sdpmlab/anser-action": "^0.3.7"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30a5eb4c051626b28e5561c49430aa98",
+    "content-hash": "6b624795cc78ae81fa66806e56414f7c",
     "packages": [
         {
             "name": "composer/semver",
@@ -1004,6 +1004,57 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "sdpmlab/anser-action",
+            "version": "v0.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SDPM-lab/Anser-Action.git",
+                "reference": "5d117f6d93e29bcf97180ce2b3004c5e49ae5851"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SDPM-lab/Anser-Action/zipball/5d117f6d93e29bcf97180ce2b3004c5e49ae5851",
+                "reference": "5d117f6d93e29bcf97180ce2b3004c5e49ae5851",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.0",
+                "php": "^7.4||^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SDPMlab\\Anser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "SDPM-lab",
+                    "homepage": "https://github.com/SDPM-lab"
+                },
+                {
+                    "name": "MonkenWu",
+                    "homepage": "https://github.com/monkenWu"
+                }
+            ],
+            "description": "PHP simple API connection library.",
+            "keywords": [
+                "api",
+                "http client",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/SDPM-lab/Anser-Action/issues",
+                "source": "https://github.com/SDPM-lab/Anser-Action/tree/v0.3.7"
+            },
+            "time": "2023-05-04T12:53:58+00:00"
         },
         {
             "name": "swow/swow",

--- a/config/Gateway.php
+++ b/config/Gateway.php
@@ -7,7 +7,7 @@ use Workerman\Worker;
 use Workerman\Protocols\Http\Request;
 use AnserGateway\Config\BaseConfig;
 
-class Gateway
+class Gateway extends BaseConfig
 {
     /**
      * Auto Reload Mode

--- a/config/Gateway.php
+++ b/config/Gateway.php
@@ -5,6 +5,7 @@ namespace Config;
 use Workerman\Connection\TcpConnection;
 use Workerman\Worker;
 use Workerman\Protocols\Http\Request;
+use AnserGateway\Config\BaseConfig;
 
 class Gateway
 {
@@ -127,6 +128,11 @@ class Gateway
         \AnserGateway\Worker\GatewayWorker::class,
         // \AnserGateway\Worker\AutoloadFileMonitor::class,
     ];
+
+    // public function __construct()
+    // {
+    //     parent::__construct();
+    // }
 
     /**
      * You can declare some additional worker setting in this method.

--- a/config/ServiceDiscovery.php
+++ b/config/ServiceDiscovery.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Config;
+
+use AnserGateway\Config\BaseConfig;
+
+class ServiceDiscovery extends BaseConfig
+{
+    /**
+     * 已完成實例化的Consul設定
+     *
+     * @var \DCarbone\PHPConsulAPI\Config
+     */
+    protected $consulConfig;
+
+    /**
+     * 需要被探索的服務名稱
+     *
+     * @var array<string>
+     */
+    public array $defaultServiceGroup = [];
+
+    /**
+     * Consul Server IP Address and port
+     *
+     * @var string
+     */
+    public string $address = 'http://localhost:8500';
+
+    /**
+     * HTTP Scheme [http or https]
+     *
+     * @var string
+     */
+    public string $scheme = 'http';
+
+    /**
+     * Consul Server DataCenter
+     *
+     * @var string
+     */
+    public string $dataCenter = '';
+
+    /**
+     * 請求間隔
+     *
+     * @var integer
+     */
+    public int $reloadTime = 10;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        // 因.env傳入為字串，故使用explode作切割
+        if(getenv('servicediscovery.defaultServiceGroup') !== ''){
+            $this->defaultServiceGroup = explode(',', getenv('servicediscovery.defaultServiceGroup'));
+        }
+    }
+}

--- a/config/ServiceDiscovery.php
+++ b/config/ServiceDiscovery.php
@@ -7,13 +7,6 @@ use AnserGateway\Config\BaseConfig;
 class ServiceDiscovery extends BaseConfig
 {
     /**
-     * 已完成實例化的Consul設定
-     *
-     * @var \DCarbone\PHPConsulAPI\Config
-     */
-    protected $consulConfig;
-
-    /**
      * 需要被探索的服務名稱
      *
      * @var array<string>

--- a/env
+++ b/env
@@ -1,0 +1,25 @@
+#--------------------------------------------------------------------
+# Gateway
+#--------------------------------------------------------------------
+
+# gateway.autoReloadMode = 'restart'
+# gateway.workerCount = 1
+# gateway.workerUser = 'www-data'
+# gateway.stdoutFile = '/dev/null'
+# gateway.listeningPort = 8080
+# gateway.ssl = false
+# gateway.sslCertFilePath = 'server.pem'
+# gateway.sslKeyFilePath = 'server.key'
+# gateway.sslVerifyPeer = false
+# gateway.sslAllowSelfSigned = false
+# gateway.defaultMaxSendBufferSize = 1048576
+# gateway.defaultMaxPackageSize = 10485760
+
+#--------------------------------------------------------------------
+# Service Discovery
+#--------------------------------------------------------------------
+# servicediscovery.defaultServiceGroup = ServiceName1,ServiceName2  # [required] Same name as the service registered on Consul, If you have more than one service, please separate them with a comma(,).
+# servicediscovery.address = 'localhost:8600'                       # [required]
+# servicediscovery.scheme  = 'http'                                 # [optional] defaults to "http"
+# servicediscovery.dataCenter = ''                                  # [optional]
+# servicediscovery.reloadTime = 300                                 # [optional] php json encode opt value to use when serializing requests

--- a/system/Config/BaseConfig.php
+++ b/system/Config/BaseConfig.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace AnserGateway\Config;
+
+class BaseConfig
+{
+    public function __construct()
+    {
+        // 取得class中的所有元素
+        $properties  = array_keys(get_object_vars($this));
+        // 對應的namespace class名稱
+        $prefix      = static::class;
+        // 切割class名稱，取得class名稱前的文字數量
+        $slashAt     = strrpos($prefix, '\\');
+        // class名稱
+        $shortPrefix = strtolower(substr($prefix, $slashAt === false ? 0 : $slashAt + 1));
+
+        foreach ($properties as $property) {
+            $this->initEnvValue($this->{$property}, $property, $prefix, $shortPrefix);
+        }
+    }
+
+    /**
+     * Initialization an environment-specific configuration setting
+     *
+     * @param array|bool|float|int|string|null $property
+     *
+     * @return void
+     */
+    protected function initEnvValue(&$property, string $name, string $prefix, string $shortPrefix)
+    {
+        if (is_array($property)) {
+            foreach (array_keys($property) as $key) {
+                $this->initEnvValue($property[$key], "{$name}.{$key}", $prefix, $shortPrefix);
+            }
+        } elseif (($value = $this->getEnvValue($name, $prefix, $shortPrefix)) !== false && $value !== null) {
+            if ($value === 'false') {
+                $value = false;
+            } elseif ($value === 'true') {
+                $value = true;
+            }
+            if (is_bool($value)) {
+                $property = $value;
+
+                return;
+            }
+
+            $value = trim($value, '\'"');
+
+            if (is_int($property)) {
+                $value = (int) $value;
+            } elseif (is_float($property)) {
+                $value = (float) $value;
+            }
+
+            $property = $value;
+        }
+    }
+
+    /**
+     * Retrieve an environment-specific configuration setting
+     *
+     * @return string|null
+     */
+    protected function getEnvValue(string $property, string $prefix, string $shortPrefix)
+    {
+        $shortPrefix        = ltrim($shortPrefix, '\\');
+        $underscoreProperty = str_replace('.', '_', $property);
+
+        switch (true) {
+            case array_key_exists("{$shortPrefix}.{$property}", $_ENV):
+                return $_ENV["{$shortPrefix}.{$property}"];
+
+            case array_key_exists("{$shortPrefix}_{$underscoreProperty}", $_ENV):
+                return $_ENV["{$shortPrefix}_{$underscoreProperty}"];
+
+            case array_key_exists("{$shortPrefix}.{$property}", $_SERVER):
+                return $_SERVER["{$shortPrefix}.{$property}"];
+
+            case array_key_exists("{$shortPrefix}_{$underscoreProperty}", $_SERVER):
+                return $_SERVER["{$shortPrefix}_{$underscoreProperty}"];
+
+            case array_key_exists("{$prefix}.{$property}", $_ENV):
+                return $_ENV["{$prefix}.{$property}"];
+
+            case array_key_exists("{$prefix}_{$underscoreProperty}", $_ENV):
+                return $_ENV["{$prefix}_{$underscoreProperty}"];
+
+            case array_key_exists("{$prefix}.{$property}", $_SERVER):
+                return $_SERVER["{$prefix}.{$property}"];
+
+            case array_key_exists("{$prefix}_{$underscoreProperty}", $_SERVER):
+                return $_SERVER["{$prefix}_{$underscoreProperty}"];
+
+            default:
+                $value = getenv("{$shortPrefix}.{$property}");
+                $value = $value === false ? getenv("{$shortPrefix}_{$underscoreProperty}") : $value;
+                $value = $value === false ? getenv("{$prefix}.{$property}") : $value;
+                $value = $value === false ? getenv("{$prefix}_{$underscoreProperty}") : $value;
+
+                return $value === false ? null : $value;
+        }
+    }
+}

--- a/system/HTTPConnectionManager.php
+++ b/system/HTTPConnectionManager.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace AnserGateway;
+
+use Swow\Psr7\Client\Client;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * HTTP 連線管理器
+ * 
+ * @version 1.0.0
+ * @author MonkenWu <monkenwu@monken.tw>
+ */
+class HTTPConnectionManager
+{
+
+    /**
+     * 目前沒有進行傳輸的連線
+     * 
+     * @var array<string,array<Client>>
+     */
+    private static $idleConnections = [];
+
+    /**
+     * 所有的連線
+     * 
+     * @var array<string,array<Client>>
+     */
+    private static $connections = [];
+
+    private static $getConnectionQueue = [];
+
+    /**
+     * 每個 host 最多連線數
+     *
+     * @var integer
+     */
+    public static $hostMaxConnectionNum = 100;
+
+    /**
+     * 連線忙碌中時等待的時間
+     *
+     * @var integer microseconds
+     */
+    public static $waitConnectionTimeout = 100;
+
+    /**
+     * 使用 connection
+     *
+     * @param string $host
+     * @param int $port
+     * @param callable $callback
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public static function useConnection(string $host, int $port, callable $callback): ResponseInterface
+    {
+        $hostName = sprintf("%s:%s", $host, $port);
+        $client = self::getConnection($host, $port);
+        $response = $callback($client);
+        //執行完畢後將 connection 放回 idle
+        self::$idleConnections[$hostName][] = $client;
+        return $response;
+    }
+
+    /**
+     * 取得 connection
+     *
+     * @param string $host
+     * @param int $port
+     * @return Client
+     */
+    protected static function getConnection(string $host, int $port)
+    {
+        $hostName = sprintf("%s:%s", $host, $port);
+
+        if(isset(self::$connections[$hostName]) == false){
+            self::$connections[$hostName] = [];
+        }
+
+        if(isset(self::$idleConnections[$hostName]) == false){
+            self::$idleConnections[$hostName] = [];
+        }
+
+        $client = self::addNewConnection($host, $port);
+
+        //如果 connection 已經斷線，則重新連線
+        if ($client->isAvailable() == false) {
+            $client->connect($host, $port);
+        }
+
+        return $client;
+    }
+
+    /**
+     * 新增 connection
+     *
+     * @param string $host
+     * @param int $port
+     * @return Client
+     */
+    protected static function addNewConnection(string $host, int $port): Client
+    {
+        $hostName = sprintf("%s:%s", $host, $port);
+
+        if(count(self::$connections[$hostName]) >= self::$hostMaxConnectionNum){
+            $uniqueId = sha1(
+                uniqid() . 
+                substr(str_shuffle(str_repeat($x='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil(10/strlen($x)) )),1,10)
+            );
+            if(isset(self::$getConnectionQueue[$hostName]) == false){
+                self::$getConnectionQueue[$hostName] = [];
+            }
+            self::$getConnectionQueue[$hostName][] = $uniqueId;
+            while (count(self::$idleConnections[$hostName]) == 0 || self::checkQueue($hostName, $uniqueId) == false) {
+                usleep(self::$waitConnectionTimeout);
+            }
+            self::shiftQueue($hostName);
+            return array_pop(self::$idleConnections[$hostName]);
+        }
+
+        $client = new \Swow\Psr7\Client\Client();
+        $client->connect($host, $port);
+        self::$connections[$hostName][] = $client;
+        return $client;
+    }
+
+    /**
+     * 檢查 queue 中是否有此 uniqueId
+     *
+     * @param string $uniqueId
+     * @return integer index
+     */
+    protected static function checkQueue(string $hostName, string $uniqueId): bool
+    {
+        if(self::$getConnectionQueue[$hostName][0] == $uniqueId){
+            return true;
+        }else{
+            return false;
+        }
+    }
+
+    /**
+     * 從 queue 中移除 uniqueId
+     *
+     * @param string $uniqueId
+     * @return void
+     */
+    protected static function shiftQueue(string $hostName)
+    {
+        array_shift(self::$getConnectionQueue[$hostName]);
+    }
+
+    public static function getConnectionInfo(){
+        $info = [];
+        foreach (self::$connections as $hostName => $connections) {
+            $info[$hostName] = [
+                'total' => count(self::$connections[$hostName]),
+                'idle' => count(self::$idleConnections[$hostName]),
+                'busy' => count(self::$connections[$hostName]) - count(self::$idleConnections[$hostName]),
+                'queue' => count(self::$getConnectionQueue[$hostName] ?? []),
+            ];
+        }
+        return $info;
+    }
+
+    public static function closeAllConnections()
+    {
+        foreach (self::$connections as $hostName => $connections) {
+            foreach ($connections as $connection) {
+                try {
+                    $connection->close();
+                } catch (\Exception $e) {
+                    //throw $th;
+                }
+            }
+        }
+    }
+
+}

--- a/system/HTTPConnectionManager.php
+++ b/system/HTTPConnectionManager.php
@@ -181,7 +181,7 @@ class HTTPConnectionManager
      *
      * @return callable
      */
-    public static function swowMiddleware()
+    public static function connectionMiddleware()
     {
         return static function (\GuzzleHttp\Psr7\Request $request, array $options) {
 

--- a/system/ServiceDiscovery/ServiceDiscovery.php
+++ b/system/ServiceDiscovery/ServiceDiscovery.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace AnserGateway\ServiceDiscovery;
+
+use Config\ServiceDiscovery as ServiceDiscoveryConfig;
+use SDPMlab\Anser\Service\Action;
+use Psr\Http\Message\ResponseInterface;
+use SDPMlab\Anser\Service\ConcurrentAction;
+use SDPMlab\Anser\Exception\ActionException;
+
+class ServiceDiscovery
+{
+    /**
+     * ServiceDiscovery 設定檔實體
+     *
+     * @var \Config\ServiceDiscovery
+     */
+    protected $serviceDiscoveryConfig;
+
+    /**
+     * 須被訪問的服務
+     *
+     * @var array
+     */
+    protected array $defaultServiceGroup = [];
+
+    /**
+     * 重新搜尋的等待Timer
+     *
+     * @var integer
+     */
+    public int $reloadTime;
+
+    /**
+     * Consul Server的真實位置 e.g. http://127.0.0.1:8500
+     *
+     * @var string
+     */
+    protected string $consulAddress;
+
+    /**
+     * 即將訪問的Consul Server DataCenter名稱
+     *
+     * @var string
+     */
+    protected string $consulDataCenter;
+
+
+    /**
+     * 從Consul Server探索的可訪問服務
+     *
+     * @var array<string,array<string,string>>
+     */
+    protected array $localServices = [];
+
+    /**
+     * 用於比對的可訪問服務，參照$service屬性
+     *
+     * @var array<string,array<string,string>>
+     */
+    protected array $localVerifyServices = [null];
+
+
+    public function __construct()
+    {
+        $this->serviceDiscoveryConfig = new ServiceDiscoveryConfig();
+        $this->defaultServiceGroup    = $this->serviceDiscoveryConfig->defaultServiceGroup;
+        $this->reloadTime             = $this->serviceDiscoveryConfig->reloadTime;
+        $this->consulDataCenter       = $this->serviceDiscoveryConfig->dataCenter;
+        $this->consulAddress          = sprintf(
+            '%s://%s',
+            strtolower($this->serviceDiscoveryConfig->scheme),
+            $this->serviceDiscoveryConfig->address,
+        );
+    }
+
+    /**
+     * 執行服務探索步驟
+     * 於ServiceDiscoverWorker被呼叫
+     *
+     * @return void|null
+     */
+    public function doServiceDiscovery()
+    {
+        $this->setLocalServices();
+
+        if(!$this->isNeedToUpdateServiceList()) {
+            return;
+        }
+
+        var_dump("update Service");
+        var_dump("---------");
+        // do update anser-action service list
+    }
+
+    /**
+     * 使用Anser-Action 做並行請求，取得所有服務資訊
+     *
+     * @return array
+     */
+    public function doFoundServices(): array
+    {
+        $actionList = [];
+
+        foreach ($this->defaultServiceGroup as $serviceName) {
+            $action = (new Action(
+                $this->consulAddress,
+                "GET",
+                "/v1/health/service/{$serviceName}"
+            ))->addOption("query", [
+                "passing" => "true",
+                "dc"      => $this->consulDataCenter
+            ])->doneHandler(function (
+                ResponseInterface $response,
+                Action $runtimeAction
+            ) {
+                $body = $response->getBody()->getContents();
+                $data = json_decode($body, true);
+                $runtimeAction->setMeaningData($data);
+            })->failHandler(function (
+                ActionException $e
+            ) {
+                if($e->isClientError()) {
+                    $e->getAction()->setMeaningData([
+                        "code" => $e->getStatusCode(),
+                        "msg" => "client error"
+                    ]);
+                } elseif ($e->isServerError()) {
+                    $e->getAction()->setMeaningData([
+                        "code" => $e->getStatusCode(),
+                        "msg" => "server error"
+                    ]);
+                } elseif($e->isConnectError()) {
+                    $e->getAction()->setMeaningData([
+                        "msg" => $e->getMessage()
+                    ]);
+                }
+            });
+            $actionList[$serviceName] = $action;
+        }
+
+        $concurrent = new ConcurrentAction();
+        $concurrent->setActions($actionList)->send();
+        return $concurrent->getActionsMeaningData();
+    }
+
+    /**
+     * 設定本地service陣列
+     *
+     * @return void
+     */
+    public function setLocalServices()
+    {
+        $this->cleanLocalServices();
+        $servicesData = $this->doFoundServices();
+        foreach ($servicesData as $serviceName => $serviceData) {
+            if(count($servicesData[$serviceName]) > 1) {
+                $this->setServices($serviceData);
+            } else {
+                if(count($serviceData) == 0) {
+                    log_message('warning', "未發現服務-{$serviceName} 於Consul進行服務探索時失效，請檢察是否於Consul註冊該服務或於Anser-Gateway設定檔(env)檢查是否設定正確。");
+                    continue;
+                }
+                $this->setService($serviceData);
+            }
+        }
+    }
+
+    /**
+     * 如服務回傳多組service的話則使用該方法
+     *
+     * @param array $services
+     * @return void
+     */
+    public function setServices(array $services): void
+    {
+        foreach ($services as $service) {
+            $serviceEntity        = $service["Service"];
+            $serviceTags          = $serviceEntity["Tags"];
+            $serviceName          = $serviceEntity["Service"];
+            $serviceAddress       = $serviceEntity["Address"];
+            $servicePort          = $serviceEntity["Port"];
+            $serviceSchemeIsHttp  = false;
+
+            foreach ($serviceTags as $tag) {
+                if (strpos($tag, 'http_scheme=') === 0) {
+                    $serviceScheme = substr($tag, strlen('http_scheme='));
+                    $serviceSchemeIsHttp = strtolower($serviceScheme) == 'http' ? false : true;
+                    break;
+                }
+            }
+
+            $this->localServices[$serviceName][] = [
+                $serviceName,
+                $serviceAddress,
+                $servicePort,
+                $serviceSchemeIsHttp
+            ];
+        }
+    }
+
+    /**
+     * 如服務只回傳一組service的話則使用該方法
+     *
+     * @param array $service
+     * @return void
+     */
+    public function setService($service): void
+    {
+        $serviceEntity        = $service[0]["Service"];
+        $serviceTags          = $serviceEntity["Tags"];
+        $serviceName          = $serviceEntity["Service"];
+        $serviceAddress       = $serviceEntity["Address"];
+        $servicePort          = $serviceEntity["Port"];
+        $serviceSchemeIsHttp  = false;
+
+        foreach ($serviceTags as $tag) {
+            if (strpos($tag, 'http_scheme=') === 0) {
+                $serviceScheme = substr($tag, strlen('http_scheme='));
+                $serviceSchemeIsHttp = strtolower($serviceScheme) == 'http' ? false : true;
+                break;
+            }
+        }
+
+        $this->localServices[$serviceName][] = [
+            $serviceName,
+            $serviceAddress,
+            $servicePort,
+            $serviceSchemeIsHttp
+        ];
+    }
+
+    /**
+     * 確認是否需要更新真實的服務列表
+     * 如新一輪的服務探索取得的服務與原有不一致，則進行ServiceList更新
+     * @return boolean
+     */
+    protected function isNeedToUpdateServiceList(): bool
+    {
+        if ($this->localServices !== $this->localVerifyServices) {
+            $this->cleanLocalVerifyServices();
+            $this->localVerifyServices = $this->localServices;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 重置$service屬性
+     *
+     * @return void
+     */
+    protected function cleanLocalServices(): void
+    {
+        $this->localServices = [];
+    }
+
+    /**
+     * 重置$verifyServices屬性
+     *
+     * @return void
+     */
+    protected function cleanLocalVerifyServices(): void
+    {
+        $this->localVerifyServices = [null];
+    }
+
+
+}

--- a/system/Worker/GatewayWorker.php
+++ b/system/Worker/GatewayWorker.php
@@ -64,7 +64,7 @@ class GatewayWorker extends WorkerRegistrar
             \AnserGateway\Worker\GatewayWorker::$routeList = RouteCollector::loadRoutes();
             \AnserGateway\Worker\GatewayWorker::$router  = new Router(\AnserGateway\Worker\GatewayWorker::$routeList);
 
-            ServiceList::setGlobalHandlerStack(HTTPConnectionManager::swowMiddleware());
+            ServiceList::setGlobalHandlerStack(HTTPConnectionManager::connectionMiddleware());
             HTTPConnectionManager::$hostMaxConnectionNum = 150;
             HTTPConnectionManager::$waitConnectionTimeout = 200;
 


### PR DESCRIPTION
**Description**
1. Append the HTTPConnectionManager class.
2. Use HTTPConnectionManager  at GatewayWork.
3. Moved the swowMiddleware callable function to HTTPConnectionManager  and rename to connectionMiddleware.
4. Composer install the Anser-Action lib.
5. Implemented the ServiceDiscovery logic.
6. Use ServiceDiscovery  at GatewayWorker.php.
7.  Implemented the BaseConfig.php, initialize .env configuration variables in BaseConfig.php.
8. Gateway configuration inheritance BaseConfig.
9. ServiceDiscovery configuration inheritance BaseConfig

**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] Conforms to style guide
